### PR TITLE
fix: Enable access to falsey props and return falsey values

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,22 @@ var obj = {animal:
 var result = objectPath(obj, 'animal/dailyNeeds/1/timeOfDay');
 console.log(result); // 'evening'
 
-var nestedArray = [
-    [
-        ['0,0,0', '0,0,1'],
-        ['0,1,0', '0,1,1']
-    ],
-    [
-        ['1,0,0', '0,0,1'],
-        ['1,1,0', '1,1,1']
-    ]
-];
-var resultNestedArray1 = objectPath(nestedArray, '0/1/1');
+var objWithArray = {
+    prop: {
+        array: [
+            [
+                ['0,0,0', '0,0,1'],
+                ['0,1,0', '0,1,1']
+            ],
+            [
+                ['1,0,0', '0,0,1'],
+                ['1,1,0', '1,1,1']
+            ]
+        ]
+    }
+};
+var resultNestedArray1 = objectPath(objWithArray, 'prop/array/0/1/1');
 console.log(resultNestedArray1); // '0,1,1'
-var resultNestedArray2 = objectPath(nestedArray, '4/0/4');
+var resultNestedArray2 = objectPath(objWithArray, 'prop/array/4/0/4');
 console.log(resultNestedArray2); // null
 ```

--- a/README.md
+++ b/README.md
@@ -1,27 +1,43 @@
 
-# Simple ObjectPath 
+# Simple ObjectPath
 
 ### JavaScript object navigation.
 
 Simple ObjectPath is a module that allows you to navigate to a given location within a Javascript object. Allows simpler access to deeply nested properties. Allows validation of existence of those same deeply nested properties.
 
 
-# Installation 
+# Installation
 ```sh
 $ npm install simple-object-path
 ```
 # Usage
 ```javascript
 var objectPath = require('simple-object-path');
-var obj = {animal: 
+
+var obj = {animal:
     {
-        type: 'Feline', 
+        type: 'Feline',
         dailyNeeds: [
-            {timeOfDay: 'morning', need: 'Breakfast'}, 
+            {timeOfDay: 'morning', need: 'Breakfast'},
             {timeOfDay: 'evening', need: 'Dinner'}
         ]
     }
 };
 var result = objectPath(obj, 'animal/dailyNeeds/1/timeOfDay');
 console.log(result); // 'evening'
+
+var nestedArray = [
+    [
+        ['0,0,0', '0,0,1'],
+        ['0,1,0', '0,1,1']
+    ],
+    [
+        ['1,0,0', '0,0,1'],
+        ['1,1,0', '1,1,1']
+    ]
+];
+var resultNestedArray1 = objectPath(nestedArray, '0/1/1');
+console.log(resultNestedArray1); // '0,1,1'
+var resultNestedArray2 = objectPath(nestedArray, '4/0/4');
+console.log(resultNestedArray2); // null
 ```

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-
 'use strict';
 
 module.exports = function objectPath(obj, path) {
 	var result = obj;
 	try{
 		var props = path.split('/');
-		props.forEach(function propsForEachCb(prop) {
-			if(result[prop]) {
-				result = result[prop];
-			} else {
+		props.every(function nestAnotherTime(prop) {
+			if (result[prop] === undefined) {
 				result = null;
+				return false;
 			}
+			result = result[prop];
+			return true;
 		});
 	} catch(e) {
 		result = null;

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ module.exports = function objectPath(obj, path) {
 	var result = obj;
 	try{
 		var props = path.split('/');
-		props.every(function nestAnotherTime(prop) {
-			if (result[prop] === undefined) {
+		props.every(function propsEveryCb(prop) {
+			if (typeof result[prop] === 'undefined') {
 				result = null;
 				return false;
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-object-path",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple object navigation",
   "main": "index.js",
   "scripts": {

--- a/test/moduleTest.js
+++ b/test/moduleTest.js
@@ -28,12 +28,11 @@ describe('Object Path tests', function describeCb() {
 		done();
 	});
 
-	it('Should find valid path through falsey props other than undefined.', function itCb(done) {
+	it('Should find valid path through falsey props.', function itCb(done) {
 		// We want to be able to access the values of 0-th indices, maybe empty strings.
-		// The rest is weird.
-		var obj = {prop: [{[false]: {'': {[null]: {[NaN]: 'val at end of weird path'}}}}]};
-		var result = objectPath(obj, 'prop/0/false//null/NaN');
-		(result).should.equal('val at end of weird path');
+		var obj = {prop: [{'': {'val of empty string': 'val of val'}}]};
+		var result = objectPath(obj, 'prop/0//val of empty string');
+		(result).should.equal('val of val');
 		done();
 	});
 

--- a/test/moduleTest.js
+++ b/test/moduleTest.js
@@ -21,4 +21,27 @@ describe('Object Path tests', function describeCb() {
 		done();
 	});
 
+	it('Should find valid path for a falsey value.', function itCb(done) {
+		var obj = {numErrors: 0};
+		var result = objectPath(obj, 'numErrors');
+		(result).should.equal(0);
+		done();
+	});
+
+	it('Should find valid path through falsey props other than undefined.', function itCb(done) {
+		// We want to be able to access the values of 0-th indices, maybe empty strings.
+		// The rest is weird.
+		var obj = {prop: [{[false]: {'': {[null]: {[NaN]: 'val at end of weird path'}}}}]};
+		var result = objectPath(obj, 'prop/0/false//null/NaN');
+		(result).should.equal('val at end of weird path');
+		done();
+	});
+
+	it('Should return null if a path is followed but the final value is undefined.', function itCb(done) {
+		var obj = {first: {second: {}}};
+		var result = objectPath(obj, 'first/second/third');
+		(result === null).should.equal(true);
+		done();
+	});
+
 });


### PR DESCRIPTION
In addition to enabling access to falsey props and returning falsey values, using .every() instead of .forEach() will short-circuit when a prop is undefined.
